### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To read more about the project, please read the official [design plan](https://g
 
 ## Next steps
 
-- Agree on a communication protocol (refer to the mockup-response.json as an example)
+- Agree on a communication protocol (refer to the [mockup-response.json](mockup-response.json) as an example)
 - Establish mockup connectivity to the front end and the database service mockup
 
 ## Running the server

--- a/mockup.go
+++ b/mockup.go
@@ -19,7 +19,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	fmt.Println("Listening on localhost:6833. Ctrl+C to exit")
+	fmt.Println("Listening on http://localhost:6833. Ctrl+C to exit")
 
 	http.HandleFunc("/", handler)
 	http.ListenAndServe(":6833", nil)


### PR DESCRIPTION
This request adds the relative link of mockup-response.json in the Readme and makes the server address click-able from terminal itself. 
